### PR TITLE
Refactor: expert/attn pools extends MuPool base, also refactor scheduler

### DIFF
--- a/csrc/bindings.cpp
+++ b/csrc/bindings.cpp
@@ -32,12 +32,12 @@ PYBIND11_MODULE(disagmoe_c, m) {
     //     .def("terminate", &MuAttnDispatcher::terminate)
     //     .def("put", &MuAttnDispatcher::put, py::arg("TensorBatch"));
 
-    py::class_<Scheduler, std::shared_ptr<Scheduler>>(m, "Scheduler")
-        .def("wait_for_new_requests", &Scheduler::wait_for_new_requests)
-        .def("schedule", &Scheduler::schedule)
-        .def("set_max_batch_size", &Scheduler::set_max_batch_size)
-        .def("get_pool_snapshot", &Scheduler::get_pool_snapshot)
-        .def("get_cur_queueing_delay", &Scheduler::get_cur_queueing_delay);
+    py::class_<ExpertScheduler, std::shared_ptr<ExpertScheduler>>(m, "ExpertScheduler")
+        .def("wait_for_new_requests", &ExpertScheduler::wait_for_new_requests)
+        .def("schedule", &ExpertScheduler::schedule)
+        .def("set_max_batch_size", &ExpertScheduler::set_max_batch_size)
+        .def("get_pool_snapshot", &ExpertScheduler::get_pool_snapshot)
+        .def("get_cur_queueing_delay", &ExpertScheduler::get_cur_queueing_delay);
         // .def("set_schedule_policy", &Scheduler::set_schedule_policy)
         // .def("set_schedule_block", &Scheduler::set_schedule_block);
 

--- a/csrc/engine/engine.cpp
+++ b/csrc/engine/engine.cpp
@@ -168,8 +168,8 @@ std::tuple<attn_scheduler_t, mu_dispatcher_t, scheduler_t, mu_dispatcher_t> init
         attn_scheduler = AttentionScheduler::build(pool, layer_ids, "mbfs");
     } 
     if (has_expert) {
-        mu_pool_t pool = std::make_shared<MuPool>(layer_ids, local_id, in_channels, LayerSchedulePolicy::GROUP, 1);
-        expert_scheduler = Scheduler::build(pool, layer_ids, "mbfs");
+        mu_expert_pool_t pool = std::make_shared<MuExpertPool>(layer_ids, local_id, in_channels, LayerSchedulePolicy::GROUP, 1);
+        expert_scheduler = ExpertScheduler::build(pool, layer_ids, "mbfs");
     }
 
     return std::make_tuple(attn_scheduler, attn_dispatcher, expert_scheduler, expert_dispatcher);
@@ -241,8 +241,8 @@ std::tuple<attn_scheduler_t, mu_dispatcher_t, scheduler_t, mu_dispatcher_t> init
 
     {
         // init expert scheduler
-        mu_pool_t pool = std::make_shared<MuPool>(layer_ids, local_id, in_channels);
-        expert_scheduler = Scheduler::build(pool, layer_ids, "mbfs");
+        mu_expert_pool_t pool = std::make_shared<MuExpertPool>(layer_ids, local_id, in_channels);
+        expert_scheduler = ExpertScheduler::build(pool, layer_ids, "mbfs");
     }
 
     return std::make_tuple(attn_scheduler, attn_dispatcher, expert_scheduler, expert_dispatcher);

--- a/csrc/engine/scheduler.cpp
+++ b/csrc/engine/scheduler.cpp
@@ -9,10 +9,6 @@
 #include <string>
 #include <set>
 
-SchedulerBase::SchedulerBase(mu_pool_t pool, std::vector<int> layer_ids, std::string policy): 
-    pool(pool), layer_ids(layer_ids), policy(policy), max_batch_size(MAX_BATCH_SIZE), cur_queueing_delay(0) {
-    
-}
 
 // void SchedulerBase::set_schedule_policy(std::string policy) {
 //     this->policy = policy;
@@ -23,22 +19,22 @@ SchedulerBase::SchedulerBase(mu_pool_t pool, std::vector<int> layer_ids, std::st
 //     this->pool->set_scheduler_block(step);
 // }
 
-scheduler_t Scheduler::build(mu_pool_t pool, std::vector<int> layer_ids, std::string policy) {
-    return std::make_shared<Scheduler>(pool, layer_ids, policy);
+scheduler_t ExpertScheduler::build(mu_expert_pool_t pool, std::vector<int> layer_ids, std::string policy) {
+    return std::make_shared<ExpertScheduler>(pool, layer_ids, policy);
 }
 
-Scheduler::Scheduler(mu_pool_t pool, std::vector<int> layer_ids, std::string policy): 
-    SchedulerBase(pool, layer_ids, policy) {
+ExpertScheduler::ExpertScheduler(mu_expert_pool_t pool, std::vector<int> layer_ids, std::string policy): 
+    pool(pool), layer_ids(layer_ids), policy(policy), max_batch_size(MAX_BATCH_SIZE), cur_queueing_delay(0) {
 
 }
 
-std::vector<TensorBatch> Scheduler::_schedule() {
+std::vector<TensorBatch> ExpertScheduler::_schedule() {
     this->pool_snapshot_ = pool->get_pool_snapshot();
     return pool->fetch_largest_batch();
 }
 
-TensorBatch Scheduler::schedule() {
-    tx_range _{"Scheduler::schedule"};
+TensorBatch ExpertScheduler::schedule() {
+    tx_range _{"ExpertScheduler::schedule"};
 
     auto batches = std::move(this->_schedule());
     auto batch = TensorBatch::merge(batches);
@@ -60,7 +56,7 @@ attn_scheduler_t AttentionScheduler::build(mu_attn_pool_t pool, std::vector<int>
 
 
 AttentionScheduler::AttentionScheduler(mu_attn_pool_t pool, std::vector<int> layer_ids, std::string policy): 
-    SchedulerBase(pool, layer_ids, policy), pool(pool) {
+    pool(pool), layer_ids(layer_ids), policy(policy), max_batch_size(MAX_BATCH_SIZE), cur_queueing_delay(0) {
     
 }
 

--- a/csrc/include/muhelper.h
+++ b/csrc/include/muhelper.h
@@ -28,6 +28,8 @@ protected:
 public:
     MuHelper(std::vector<int> layer_ids, int device_id, std::vector<Channel_t> channels);
 
+    virtual ~MuHelper();
+
     void start();
 
     void init_cuda_device();
@@ -172,7 +174,7 @@ protected:
 
     void recv_tensor(int peer_id, uintptr_t tensor_buf, metadata_t &meta);
 
-    virtual void process_batch(torch::Tensor tensor, metadata_t &meta, bool send_from_zmq=true);
+    virtual void process_batch(torch::Tensor tensor, metadata_t &meta, bool send_from_zmq=true) = 0;
 
     void start_queueing_timer(const std::vector<int> &req_ids);
 
@@ -187,8 +189,10 @@ public:
         std::vector<Channel_t> channels,
         LayerSchedulePolicy policy = LayerSchedulePolicy::ADVANCED,
         int num_groups = 1,
-        bool is_attn = false
+        int local_zmq_port_offset = 0
     );
+
+    virtual ~MuPool();
 
     void run() override;
 
@@ -229,7 +233,26 @@ public:
     float remove_queueing_timer(const std::vector<int> &req_ids);
 };
 
-typedef std::shared_ptr<MuPool> mu_pool_t;
+class MuExpertPool: public MuPool {
+protected:
+    std::vector<std::vector<TensorBatch>> data_queue;
+
+    void process_batch(torch::Tensor tensor, metadata_t &meta, bool send_from_zmq=true) override;
+
+public:
+    MuExpertPool(
+        std::vector<int> layer_ids,
+        int device_id,
+        std::vector<Channel_t> channels,
+        LayerSchedulePolicy policy = LayerSchedulePolicy::ADVANCED,
+        int num_groups = 1
+    );
+
+    std::vector<TensorBatch> fetch_largest_batch();
+};
+
+typedef std::shared_ptr<MuExpertPool> mu_expert_pool_t;
+typedef std::shared_ptr<MuExpertPool> mu_pool_t;  // For backward compatibility
 typedef std::shared_ptr<MuDispatcher> mu_dispatcher_t;
 
 class MuAttentionPool: public MuPool {

--- a/csrc/include/scheduler.h
+++ b/csrc/include/scheduler.h
@@ -13,14 +13,18 @@
 #include "cuda_utils.h"
 #include "utils.hpp"
 
-class Scheduler;
+/*
+    ExpertScheduler and AttentionScheduler are thin wrappers around the pools.
+    Layer-wise schedulers are implemented with actual scheduling logics.
+*/
 
-typedef std::shared_ptr<Scheduler> scheduler_t;
+class ExpertScheduler;
 
-class SchedulerBase {
+typedef std::shared_ptr<ExpertScheduler> scheduler_t;
+
+class ExpertScheduler {
 protected:
-    mu_pool_t pool;
-
+    mu_expert_pool_t pool;
     std::vector<int> layer_ids;
 
     std::string policy;
@@ -31,8 +35,12 @@ protected:
 
     std::vector<int> pool_snapshot_{};
 
+    std::vector<TensorBatch> _schedule();
+
 public:
-    SchedulerBase(mu_pool_t pool, std::vector<int> layer_ids, std::string policy = "mbfs");
+    ExpertScheduler(mu_expert_pool_t pool, std::vector<int> layer_ids, std::string policy = "mbfs");
+
+    static scheduler_t build(mu_expert_pool_t pool, std::vector<int> layer_ids, std::string policy = "mbfs");
 
     void start() {
         this->pool->start();
@@ -55,21 +63,11 @@ public:
         return cur_queueing_delay;
     }
 
+    TensorBatch schedule();
+
     // void set_schedule_policy(std::string policy);
 
     // void set_schedule_block(int step);
-};
-
-class Scheduler: public SchedulerBase {
-protected:
-    std::vector<TensorBatch> _schedule();
-
-public:
-    Scheduler(mu_pool_t pool, std::vector<int> layer_ids, std::string policy = "mbfs");
-
-    static scheduler_t build(mu_pool_t pool, std::vector<int> layer_ids, std::string policy = "mbfs");
-
-    TensorBatch schedule();
 };
 
 
@@ -77,9 +75,14 @@ class AttentionScheduler;
 
 typedef std::shared_ptr<AttentionScheduler> attn_scheduler_t;
 
-class AttentionScheduler: public SchedulerBase {
+class AttentionScheduler {
 protected:
     mu_attn_pool_t pool;
+    std::vector<int> layer_ids;
+    std::string policy;
+    float cur_queueing_delay;
+    int max_batch_size;
+    std::vector<int> pool_snapshot_{};
 
     virtual std::vector<AttentionBatch> _schedule();
 
@@ -87,6 +90,27 @@ public:
     AttentionScheduler(mu_attn_pool_t pool, std::vector<int> layer_ids, std::string policy = "mbfs");
 
     static attn_scheduler_t build(mu_attn_pool_t pool, std::vector<int> layer_ids, std::string policy = "mbfs");
+
+    void start() {
+        this->pool->start();
+    }
+
+    void wait_for_new_requests() {
+        this->pool->wait_for_new_requests();
+    }
+
+    void set_max_batch_size(int max_batch_size) {
+        this->max_batch_size = max_batch_size;
+        this->pool->set_max_batch_size(max_batch_size);
+    }
+
+    std::vector<int> get_pool_snapshot() {
+        return pool_snapshot_;
+    };
+
+    float get_cur_queueing_delay() const {
+        return cur_queueing_delay;
+    }
 
     virtual AttentionBatch schedule();
 

--- a/csrc/muhelper/muhelper.cpp
+++ b/csrc/muhelper/muhelper.cpp
@@ -29,6 +29,8 @@ MuHelper::MuHelper(std::vector<int> layer_ids, int device_id, std::vector<Channe
         DMOE_LOG(INFO) << "init muhelper@" << device_id << LEND;
     }
 
+MuHelper::~MuHelper() {}
+
 void MuHelper::start() {
     DMOE_LOG(INFO) << "muhelper@" << device_id << " start" << LEND;
     this->thread = std::thread(
@@ -332,14 +334,13 @@ MuPool::MuPool(
     std::vector<Channel_t> channels,
     LayerSchedulePolicy policy,
     int num_groups,
-    bool is_attn): 
+    int local_zmq_port_offset): 
     MuHelper(layer_ids, device_id, channels),
     num_groups(num_groups), 
-    is_attn(is_attn),
     ctx(channels.size()),
     mq(ctx, zmq::socket_type::pull),
-    max_batch_size(MAX_BATCH_SIZE) {
-    this->local_zmq_port_offset = 0;
+    max_batch_size(MAX_BATCH_SIZE),
+    local_zmq_port_offset(local_zmq_port_offset) {
     int num_layers = layer_ids.size();
     int max_layer_id = 0;
     for (auto id: layer_ids)
@@ -348,7 +349,6 @@ MuPool::MuPool(
     this->layer_id_P2V = std::vector<int>(max_layer_id + 1);
     this->layer_id_V2P = std::vector<int>(num_layers);
 
-    this->data_queue = std::vector<std::vector<TensorBatch>>(num_layers * num_groups);
     for (size_t i = 0; i < num_layers; i ++) {
         this->layer_id_P2V[layer_ids[i]] = i;
         this->layer_id_V2P[i] = layer_ids[i];
@@ -385,6 +385,8 @@ MuPool::MuPool(
     }
 }
 
+MuPool::~MuPool() {}
+
 void MuPool::recv_metadata(int &peer_id, metadata_t &meta) {
     // DMOE_LOG(DEBUG) << "fetching a msg ..." << LEND;
         
@@ -409,45 +411,7 @@ void MuPool::recv_tensor(int peer_id, uintptr_t tensor_buf, metadata_t &meta) {
     this->peer_channels[peer_id]->recv(tensor_buf, *meta);
 }
 
-void MuPool::process_batch(torch::Tensor tensor, metadata_t &meta, bool send_from_zmq) {
-    // TODO(hogura|20241014): sync prefill sequences
-    /*
-    TODO(shaoyuw|20241011): separate sequences into waiting queue and running queue
-    completed_sequences = fill(batch)
-    flash_attn_metadata = concat(completed_sequences, decode_tokens from batch)
-
-
-    1. split batch to prefill and decode tokens
-    2. use prefill tokens to compose prefill sequence (sync for prefill sequences) (memcpy, custom kernel)
-    3. if a prefill sequence is complete, check if this sequence exists in block table
-    4. if not, add them to waiting queue; else add to corresponding running queue with decoding tokens (memcpy)
-
-    waiting_queue, each element is a sequence
-
-    running_queue[layers]
-
-    */
-    int lid = this->layer_id_P2V[meta->layer_id];
-    int num_tokens = meta->num_tokens();
-
-    if (this->num_groups > 1) {
-        lid = get_layer_group_id(lid, meta->get_dp_rank() % this->num_groups);
-    }
-    
-    {
-        std::lock_guard<std::mutex> lock(this->batch_mutex);
-        this->data_queue[lid].push_back((TensorBatch) {tensor, meta});
-        this->layer_scheduler->add_tokens_to_layer(lid, num_tokens);
-        this->num_batches_per_layer_[lid] += 1;
-        int &tokens_cur_layer = this->tokens_per_layer_[lid];
-        tokens_cur_layer += num_tokens;
-        if (tokens_cur_layer > this->largest_batch_size_) {
-            this->largest_batch_size_ = tokens_cur_layer;
-            this->largest_batch_layer_id_ = lid;
-        }
-
-    }
-}
+// Base MuPool process_batch is pure virtual - implemented in derived classes
 
 void MuPool::start_queueing_timer(const std::vector<int> &req_ids) {
     if (req_ids.empty())
@@ -497,14 +461,14 @@ void MuPool::run() {
         int peer_id;
         metadata_t meta;
 
-        MuPool::recv_metadata(peer_id, meta);
+        recv_metadata(peer_id, meta);
 
         torch::Tensor tensor = torch::empty(
             {meta->num_tokens(), meta->token_hidden_dim()}, 
             torch::TensorOptions().dtype(torch::kBFloat16).device(torch::kCUDA, 0)
         );
 
-        MuPool::recv_tensor(peer_id, (uintptr_t)tensor.data_ptr(), meta);
+        recv_tensor(peer_id, (uintptr_t)tensor.data_ptr(), meta);
 
         // NOTE(hogura|20250305): after receiving batch, start the queueing timer for each request
         // this->start_queueing_timer(meta->req_ids);
@@ -562,7 +526,41 @@ std::vector<int> MuPool::get_pool_snapshot() {
     return snapshot;
 }
 
-std::vector<TensorBatch> MuPool::fetch_largest_batch() {
+MuExpertPool::MuExpertPool(
+    std::vector<int> layer_ids,
+    int device_id,
+    std::vector<Channel_t> channels,
+    LayerSchedulePolicy policy,
+    int num_groups):
+    MuPool(layer_ids, device_id, channels, policy, num_groups, 0) {
+    int num_layers = layer_ids.size();
+    this->data_queue = std::vector<std::vector<TensorBatch>>(num_layers * num_groups);
+}
+
+void MuExpertPool::process_batch(torch::Tensor tensor, metadata_t &meta, bool send_from_zmq) {
+    int lid = this->layer_id_P2V[meta->layer_id];
+    int num_tokens = meta->num_tokens();
+
+    if (this->num_groups > 1) {
+        lid = get_layer_group_id(lid, meta->get_dp_rank() % this->num_groups);
+    }
+    
+    {
+        std::lock_guard<std::mutex> lock(this->batch_mutex);
+        this->data_queue[lid].push_back((TensorBatch) {tensor, meta});
+        this->layer_scheduler->add_tokens_to_layer(lid, num_tokens);
+        this->num_batches_per_layer_[lid] += 1;
+        int &tokens_cur_layer = this->tokens_per_layer_[lid];
+        tokens_cur_layer += num_tokens;
+        if (tokens_cur_layer > this->largest_batch_size_) {
+            this->largest_batch_size_ = tokens_cur_layer;
+            this->largest_batch_layer_id_ = lid;
+        }
+
+    }
+}
+
+std::vector<TensorBatch> MuExpertPool::fetch_largest_batch() {
     std::lock_guard<std::mutex> lock(this->batch_mutex);
 
     if (this->largest_batch_size_ == 0) {
@@ -606,10 +604,9 @@ MuAttentionPool::MuAttentionPool(
     std::vector<int> device_group_ids,
     Channel_t group_comm,
     LayerSchedulePolicy policy
-): MuPool(layer_ids, device_id, channels, policy, /* num_groups */ 1, true), 
+): MuPool(layer_ids, device_id, channels, policy, /* num_groups */ 1, /* local_zmq_port_offset */ 1), 
     device_group_ids(device_group_ids),
     group_comm(group_comm.get() != nullptr ? std::dynamic_pointer_cast<NcclGroupChannel>(group_comm) : nullptr) {
-    this->local_zmq_port_offset = 1;
     int num_layers = layer_ids.size();
     this->attn_data_queue = std::vector<std::vector<AttentionBatch>>(num_layers);
 }

--- a/disagmoe/frontend/adapter.py
+++ b/disagmoe/frontend/adapter.py
@@ -4,7 +4,7 @@ from disagmoe.frontend.datatypes import TensorBatch, AttentionBatchMetadata, Slo
 
 from typing import Tuple, List, Dict, Optional
 
-class Scheduler:
+class ExpertScheduler:
 
     def wait_for_new_requests(self) -> None:
         ...

--- a/disagmoe/frontend/engine.py
+++ b/disagmoe/frontend/engine.py
@@ -5,7 +5,7 @@ import os
 
 from disagmoe.executor.executor import Executor, ExpertsExecutor, AttnExecutor, CUDAGraphAttnExecutor
 from disagmoe.config import ModelConfig, CacheConfig
-from disagmoe.frontend.adapter import Scheduler, MuDispatcher, Sampler, Tokenizer, BlockManager
+from disagmoe.frontend.adapter import ExpertScheduler, MuDispatcher, Sampler, Tokenizer, BlockManager
 from disagmoe.frontend.datatypes import (Metadata, ChannelInfo, TensorBatch,
                                          AttentionBatchMetadata, SloStat, TraceContext,
                                          SamplerStepInfo)
@@ -24,7 +24,7 @@ from disagmoe.env import ENV_VARS
 
 from vllm.attention.backends.flash_attn import FlashAttentionMetadata
 
-from typing import Optional, List, Dict, Callable, Tuple
+from typing import Optional, List, Dict, Callable, Tuple, Union
 from threading import Thread
 
 from torch import Tensor
@@ -34,6 +34,7 @@ import torch.distributed as dist
 from disagmoe_c import (init_engine, init_engine_colocate, start_engine, init_sampler, init_tokenizer, set_hosts, prepare_batch_infos,
                         TensorBatch as TensorBatch_C,
                         BlockManager as BlockManager_C,
+                        AttentionScheduler,
                         recorder_create as disagmoe_recorder_create,
                         recorder_output as disagmoe_recorder_output)
 
@@ -47,7 +48,7 @@ class EngineType(enum.Enum):
 class Engine:
 
     def __init__(self, 
-                 scheduler: Optional[Scheduler] = None, 
+                 scheduler: Optional[ExpertScheduler] = None, 
                  executor: Optional[Executor] = None, 
                  dispatcher: Optional[MuDispatcher] = None, 
                  device_id: Optional[int] = None):
@@ -57,11 +58,11 @@ class Engine:
         assert dispatcher is None, "Dispatcher is initialization should be done in setup_engine"
         
         self.device_id = device_id
-        self.scheduler: Scheduler = None
+        self.scheduler: Union[ExpertScheduler, AttentionScheduler] = None
         self.executor: Executor = None
         self.dispatcher: MuDispatcher = None
-        self.attn_scheduler: Scheduler = None
-        self.expert_scheduler: Scheduler = None
+        self.attn_scheduler: AttentionScheduler = None
+        self.expert_scheduler: ExpertScheduler = None
         self.attn_executor: AttnExecutor = None
         self.expert_executor: ExpertsExecutor = None
         self.attn_dispatcher: MuDispatcher = None
@@ -189,9 +190,18 @@ class Engine:
         
         self.model_config.layer_ids = core_args.layer_ids
             
-        self._logger.info(f"launching core: {core_args.layer_ids, core_args.in_device_ids, \
-                          core_args.out_device_ids, core_args.out_channel_infos, \
-                          core_args.device_group_ids, core_args.expert_ranks, core_args.local_attn_dp_rank}")
+        self._logger.info(
+            "launching core: %s",
+            (
+                core_args.layer_ids,
+                core_args.in_device_ids,
+                core_args.out_device_ids,
+                core_args.out_channel_infos,
+                core_args.device_group_ids,
+                core_args.expert_ranks,
+                core_args.local_attn_dp_rank,
+            ),
+        )
         
         # self._logger.info(f"launching core: {core_args.in_nccl_ids, core_args.out_nccl_ids, core_args.group_nccl_ids}")
         

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ See `.gitmodules`.
 
 ```bash
 sudo apt-get install libzmq3-dev libcereal-dev
-git submodule update --init
+git submodule update --init --recursive
 pip install -r requirements.txt
 ```
 
@@ -23,7 +23,7 @@ We hack and adopt the attention implementation of vLLM. A patch should be applie
 
 ```
 
-cd path/to/vllm
+cd path/to/python-version/site-packages
 
 git apply DisagMoE/patches/vllm_0.8.2.patch
 


### PR DESCRIPTION
- Re-organize the inheritance: expert/attn pools both extends the MuPool base.
- Also refactor the wrapper scheduler classes: remove the SchedulerBase. Now Expert/AttentionScheduler each manage a exper/attn pool.